### PR TITLE
Updated device_name in Packer file

### DIFF
--- a/Packer/AWS/baseJenkinsEC2.json
+++ b/Packer/AWS/baseJenkinsEC2.json
@@ -33,10 +33,10 @@
         "force_deregister": "true",
 	"ami_block_device_mappings": [
 		{
-			"device_name": "/dev/sda1",
+			"device_name": "/dev/sdc",
                         "volume_type": "gp2",
                         "volume_size": 8,
-			"delete_on_termination": true    
+			"delete_on_termination": true
 		}
 	],
 	"launch_block_device_mappings": [
@@ -67,4 +67,3 @@
 	}
    ]
 }
-


### PR DESCRIPTION
Small update to the `baseJenkinsEC2.json` file. `/dev/sda1` device is no longer supported when creating a new EC2 instance.
